### PR TITLE
feat(module/transit_gateway_attachment): enable existing attachement

### DIFF
--- a/modules/transit_gateway_attachment/README.md
+++ b/modules/transit_gateway_attachment/README.md
@@ -34,19 +34,22 @@ No modules.
 | [aws_ec2_transit_gateway_route_table_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
 | [aws_ec2_transit_gateway_route_table_propagation.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_propagation) | resource |
 | [aws_ec2_transit_gateway_vpc_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment) | resource |
+| [aws_ec2_transit_gateway_vpc_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_transit_gateway_vpc_attachment) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_appliance_mode_support"></a> [appliance\_mode\_support](#input\_appliance\_mode\_support) | See the [provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment). | `string` | `"enable"` | no |
+| <a name="input_create"></a> [create](#input\_create) | Trigger module mode between creating a new TGW Attachment or retrieving an existing one. | `bool` | `true` | no |
 | <a name="input_dns_support"></a> [dns\_support](#input\_dns\_support) | See the [provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment). | `string` | `null` | no |
+| <a name="input_id"></a> [id](#input\_id) | ID of an existing TGW Attachment. Used in conjunction with `create = false`. When set, takes precedence over `var.name`. | `string` | `null` | no |
 | <a name="input_ipv6_support"></a> [ipv6\_support](#input\_ipv6\_support) | See the [provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment). | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Optional readable name of the TGW attachment object. It is assigned to the usual AWS Name tag. | `string` | `null` | no |
 | <a name="input_propagate_routes_to"></a> [propagate\_routes\_to](#input\_propagate\_routes\_to) | Map of route propagations from this attachment. Each key is an arbitrary string, each value is the id of a TGW route table which should receive the routes to the attached VPC CIDRs. | `map(string)` | `{}` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | The attachment's subnets as a map. Each key is the availability zone name and each object has an attribute<br>`id` identifying AWS subnet.<br>All subnets in the map obtain virtual network interfaces attached to the TGW.<br>Example for users of module `subnet_set`:<pre>subnets = module.subnet_set.subnets</pre>Example:<pre>subnets = {<br>  "us-east-1a" = { id = "snet-123007" }<br>  "us-east-1b" = { id = "snet-123008" }<br>}</pre> | <pre>map(object({<br>    id = string<br>  }))</pre> | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS tags to assign to all the created objects. | `map(string)` | `{}` | no |
-| <a name="input_transit_gateway_route_table"></a> [transit\_gateway\_route\_table](#input\_transit\_gateway\_route\_table) | TGW's route table which should receive the traffic coming from the `subnet_set` (also called an association). An object with at least two attributes:<pre>transit_gateway_route_table = {<br>  id                 = "tgw-rtb-1234"<br>  transit_gateway_id = "tgw-1234"<br>}</pre> | <pre>object({<br>    id                 = string<br>    transit_gateway_id = string<br>  })</pre> | n/a | yes |
+| <a name="input_transit_gateway_route_table"></a> [transit\_gateway\_route\_table](#input\_transit\_gateway\_route\_table) | TGW's route table which should receive the traffic coming from the `subnet_set` (also called an association). An object with at least two attributes:<pre>transit_gateway_route_table = {<br>  id                 = "tgw-rtb-1234"<br>  transit_gateway_id = "tgw-1234"<br>}</pre> | <pre>object({<br>    id                 = string<br>    transit_gateway_id = string<br>  })</pre> | <pre>{<br>  "id": null,<br>  "transit_gateway_id": null<br>}</pre> | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | AWS identifier of a VPC containing the Attachment. | `string` | n/a | yes |
 
 ### Outputs

--- a/modules/transit_gateway_attachment/main.tf
+++ b/modules/transit_gateway_attachment/main.tf
@@ -1,4 +1,11 @@
+
+locals {
+  transit_gateway_attachment = var.create ? aws_ec2_transit_gateway_vpc_attachment.this[0] : data.aws_ec2_transit_gateway_vpc_attachment.this[0]
+}
+
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
+  count = var.create ? 1 : 0
+
   vpc_id                                          = var.vpc_id
   subnet_ids                                      = [for _, subnet in var.subnets : subnet.id]
   transit_gateway_id                              = var.transit_gateway_route_table.transit_gateway_id
@@ -10,14 +17,31 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
   tags                                            = merge(var.tags, var.name != null ? { Name = var.name } : {})
 }
 
+data "aws_ec2_transit_gateway_vpc_attachment" "this" {
+  count = var.create == false ? 1 : 0
+
+  # ID of an existing transit gateway attachment. By default set to `null` hence can be referenced directly.
+  id = var.id
+  # Filtering existing transit gateway attachment by name, only in case no ID was provided.
+  dynamic "filter" {
+    for_each = var.id == null ? [1] : []
+    content {
+      name   = "tag:Name"
+      values = [var.name]
+    }
+  }
+}
+
 resource "aws_ec2_transit_gateway_route_table_association" "this" {
-  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this.id
+  count = var.create ? 1 : 0
+
+  transit_gateway_attachment_id  = local.transit_gateway_attachment.id
   transit_gateway_route_table_id = var.transit_gateway_route_table.id
 }
 
 resource "aws_ec2_transit_gateway_route_table_propagation" "this" {
-  for_each = var.propagate_routes_to
+  for_each = var.create ? var.propagate_routes_to : {}
 
-  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this.id
+  transit_gateway_attachment_id  = local.transit_gateway_attachment.id
   transit_gateway_route_table_id = each.value
 }

--- a/modules/transit_gateway_attachment/outputs.tf
+++ b/modules/transit_gateway_attachment/outputs.tf
@@ -1,11 +1,11 @@
 output "attachment" {
   description = "The entire `aws_ec2_transit_gateway_vpc_attachment` object."
-  value       = aws_ec2_transit_gateway_vpc_attachment.this
+  value       = local.transit_gateway_attachment
 }
 
 output "subnets" {
   description = "Same as the input `subnets`. Intended to be used as a dependency."
-  value       = contains(aws_ec2_transit_gateway_vpc_attachment.this.subnet_ids, "!") == false ? var.subnets : null
+  value       = contains(local.transit_gateway_attachment.subnet_ids, "!") == false ? var.subnets : null
 }
 
 output "next_hop_set" {
@@ -23,7 +23,7 @@ output "next_hop_set" {
   EOF
   value = {
     type = "transit_gateway"
-    id   = aws_ec2_transit_gateway_vpc_attachment.this.transit_gateway_id
+    id   = local.transit_gateway_attachment.transit_gateway_id
     ids  = {}
   }
 }

--- a/modules/transit_gateway_attachment/variables.tf
+++ b/modules/transit_gateway_attachment/variables.tf
@@ -1,3 +1,15 @@
+variable "create" {
+  description = "Trigger module mode between creating a new TGW Attachment or retrieving an existing one."
+  default     = true
+  type        = bool
+}
+
+variable "id" {
+  description = "ID of an existing TGW Attachment. Used in conjunction with `create = false`. When set, takes precedence over `var.name`."
+  default     = null
+  type        = string
+}
+
 variable "vpc_id" {
   description = "AWS identifier of a VPC containing the Attachment."
   type        = string
@@ -65,6 +77,10 @@ variable "transit_gateway_route_table" {
   }
   ```
   EOF
+  default = {
+    id                 = null
+    transit_gateway_id = null
+  }
   type = object({
     id                 = string
     transit_gateway_id = string


### PR DESCRIPTION
## Description

The PR introduces new feature required to reuse existing AWS resources.

## Motivation and Context

For the brownfield deployment. The PR supports already created TGW with attachment associated with subnets in VPC. The routing entries depends on transit gateway attachment, thus adding custom routing via TGW is not supported without workarounds. 

## How Has This Been Tested?

It was tested against existing centralized example.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
