### PR TITLE
fix(module/panorama): alias kms variable

### DIFF
--- a/examples/panorama_standalone/README.md
+++ b/examples/panorama_standalone/README.md
@@ -86,8 +86,6 @@ Use a web browser to access https://x.x.x.x and login with admin and your previo
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_ebs_default_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
-| [aws_kms_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/panorama_standalone/example.tfvars
+++ b/examples/panorama_standalone/example.tfvars
@@ -94,7 +94,7 @@ panoramas = {
         }
       ]
       encrypted     = true
-      kms_key_alias = "aws/ebs"
+      kms_key_alias = "alias/aws/ebs"
     }
 
     iam = {

--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -24,7 +24,7 @@ data "aws_ebs_default_kms_key" "current" {
 # Retrieve an alias for the KMS key for EBS encryption
 data "aws_kms_alias" "current_arn" {
   count = var.ebs_encrypted ? 1 : 0
-  name  = data.aws_ebs_default_kms_key.current[0].key_arn
+  name  = coalesce(var.ebs_kms_key_alias, data.aws_ebs_default_kms_key.current[0].key_arn)
 }
 
 # Create the Panorama Instance
@@ -53,7 +53,7 @@ resource "aws_instance" "this" {
   root_block_device {
     delete_on_termination = true
     encrypted             = var.ebs_encrypted
-    kms_key_id            = var.ebs_encrypted == false ? null : coalesce(var.ebs_kms_key_alias, data.aws_kms_alias.current_arn[0].target_key_arn)
+    kms_key_id            = var.ebs_encrypted == false ? null : data.aws_kms_alias.current_arn[0].target_key_arn
   }
 
   tags = merge(var.global_tags, { Name = var.name })
@@ -75,7 +75,7 @@ resource "aws_ebs_volume" "this" {
   availability_zone = var.availability_zone
   size              = try(each.value.ebs_size, "2000")
   encrypted         = var.ebs_encrypted
-  kms_key_id        = var.ebs_encrypted == false ? null : coalesce(var.ebs_kms_key_alias, data.aws_kms_alias.current_arn[0].target_key_arn)
+  kms_key_id        = var.ebs_encrypted == false ? null : data.aws_kms_alias.current_arn[0].target_key_arn
 
   tags = merge(var.global_tags, { Name = try(each.value.name, var.name) })
 }


### PR DESCRIPTION
## Description

A KMS alias variable definition should be provided based on alias or use default AWS managed KMS key.
It is required for the logging disks and root disk in Panorama.

## Motivation and Context

The KMS should be unified among all examples and modules.

## How Has This Been Tested?

If there is no kms_key_alias variable provided or value will be set `alias/awk/ebs` it will use AWS managed.
For custom manage KMS the policy should be applied into key as a prerequisite. 

On Panorama disks can be validated:
```show system disk details```

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
