### PR TITLE
feat(modules/asg): Define tags for network interfaces created by Lambda

### DIFF
--- a/modules/asg/main.tf
+++ b/modules/asg/main.tf
@@ -44,6 +44,7 @@ locals {
   }
   lambda_config = {
     region = var.region
+    tags   = local.tags_merged
   }
 }
 
@@ -221,11 +222,14 @@ resource "aws_iam_role_policy" "lambda_iam_policy_default" {
                 "ec2:AssociateAddress",
                 "ec2:AttachNetworkInterface",
                 "ec2:CreateNetworkInterface",
+                "ec2:CreateTags",
                 "ec2:DescribeAddresses",
                 "ec2:DescribeInstances",
                 "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
                 "ec2:DescribeSubnets",
                 "ec2:DeleteNetworkInterface",
+                "ec2:DeleteTags",
                 "ec2:DetachNetworkInterface",
                 "ec2:DisassociateAddress",
                 "ec2:ModifyNetworkInterfaceAttribute",

--- a/modules/asg/scripts/lambda.py
+++ b/modules/asg/scripts/lambda.py
@@ -192,7 +192,18 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
 
         self.logger.debug(f"DEBUG: create_interface: instance_id={instance_id}, subnet_id={subnet_id}, sg_id={sg_id}")
         try:
-            network_interface = self.ec2_client.create_network_interface(SubnetId=subnet_id, Groups=[sg_id])
+            tags = loads(getenv('lambda_config')).get('tags')
+            tag_specifications = [{'Key': k, 'Value': v} for k, v in tags.items()]
+            network_interface = self.ec2_client.create_network_interface(
+                SubnetId=subnet_id,
+                Groups=[sg_id],
+                TagSpecifications=[
+                    {
+                        'ResourceType': 'network-interface',
+                        'Tags': tag_specifications
+                    },
+                ]
+            )
             network_interface_id = network_interface['NetworkInterface']['NetworkInterfaceId']
             self.logger.info(f"Created network interface: {network_interface_id}")
             return network_interface_id


### PR DESCRIPTION
## Description

PR:
- extends Python code in Lambda used to create network interfaces - added code allows to define tags for newly created NICs
- extends IAM role policy used by Lambda - additional permissions for creating, describing and removing tags were added
- defines tags as environment variable in Lambda configuration

## Motivation and Context

Resolves #31 

## How Has This Been Tested?

Code was tested by deploying `combined_design_autoscale` example in the lab and via ChatOps.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
