### PR TITLE
fix(examples): Remove redundant ingress rules in vmseries_mgmt security group

### DIFF
--- a/examples/centralized_design/example.tfvars
+++ b/examples/centralized_design/example.tfvars
@@ -107,16 +107,6 @@ vpcs = {
             type        = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
             cidr_blocks = ["10.0.0.0/8"]
           }
-          panorama_mgmt = {
-            description = "Permit Panorama Management"
-            type        = "ingress", from_port = "3978", to_port = "3978", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
-          panorama_log = {
-            description = "Permit Panorama Logging"
-            type        = "ingress", from_port = "28443", to_port = "28443", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
         }
       }
       vmseries_public = {

--- a/examples/centralized_design_autoscale/example.tfvars
+++ b/examples/centralized_design_autoscale/example.tfvars
@@ -107,16 +107,6 @@ vpcs = {
             type        = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
             cidr_blocks = ["10.0.0.0/8"]
           }
-          panorama_mgmt = {
-            description = "Permit Panorama Management"
-            type        = "ingress", from_port = "3978", to_port = "3978", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
-          panorama_log = {
-            description = "Permit Panorama Logging"
-            type        = "ingress", from_port = "28443", to_port = "28443", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
         }
       }
       vmseries_public = {

--- a/examples/combined_design/example.tfvars
+++ b/examples/combined_design/example.tfvars
@@ -107,16 +107,6 @@ vpcs = {
             type        = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
             cidr_blocks = ["10.0.0.0/8"]
           }
-          panorama_mgmt = {
-            description = "Permit Panorama Management"
-            type        = "ingress", from_port = "3978", to_port = "3978", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
-          panorama_log = {
-            description = "Permit Panorama Logging"
-            type        = "ingress", from_port = "28443", to_port = "28443", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
         }
       }
       vmseries_public = {

--- a/examples/combined_design_autoscale/example-natgw-lambda-vpc.tfvars
+++ b/examples/combined_design_autoscale/example-natgw-lambda-vpc.tfvars
@@ -122,16 +122,6 @@ vpcs = {
             type        = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
             cidr_blocks = ["10.0.0.0/8"]
           }
-          panorama_mgmt = {
-            description = "Permit Panorama Management"
-            type        = "ingress", from_port = "3978", to_port = "3978", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
-          panorama_log = {
-            description = "Permit Panorama Logging"
-            type        = "ingress", from_port = "28443", to_port = "28443", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
         }
       }
       vmseries_public = {

--- a/examples/combined_design_autoscale/example-no-natgw-lambda-no-vpc.tfvars
+++ b/examples/combined_design_autoscale/example-no-natgw-lambda-no-vpc.tfvars
@@ -107,16 +107,6 @@ vpcs = {
             type        = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
             cidr_blocks = ["10.0.0.0/8"]
           }
-          panorama_mgmt = {
-            description = "Permit Panorama Management"
-            type        = "ingress", from_port = "3978", to_port = "3978", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
-          panorama_log = {
-            description = "Permit Panorama Logging"
-            type        = "ingress", from_port = "28443", to_port = "28443", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
         }
       }
       vmseries_public = {

--- a/examples/combined_design_autoscale/example.tfvars
+++ b/examples/combined_design_autoscale/example.tfvars
@@ -107,16 +107,6 @@ vpcs = {
             type        = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
             cidr_blocks = ["10.0.0.0/8"]
           }
-          panorama_mgmt = {
-            description = "Permit Panorama Management"
-            type        = "ingress", from_port = "3978", to_port = "3978", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
-          panorama_log = {
-            description = "Permit Panorama Logging"
-            type        = "ingress", from_port = "28443", to_port = "28443", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
         }
       }
       vmseries_public = {

--- a/examples/isolated_design/example.tfvars
+++ b/examples/isolated_design/example.tfvars
@@ -107,16 +107,7 @@ vpcs = {
             type        = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
             cidr_blocks = ["10.0.0.0/8"]
           }
-          panorama_mgmt = {
-            description = "Permit Panorama Management"
-            type        = "ingress", from_port = "3978", to_port = "3978", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
-          panorama_log = {
-            description = "Permit Panorama Logging"
-            type        = "ingress", from_port = "28443", to_port = "28443", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
+
         }
       }
       vmseries_public = {

--- a/examples/isolated_design/example.tfvars
+++ b/examples/isolated_design/example.tfvars
@@ -107,7 +107,6 @@ vpcs = {
             type        = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
             cidr_blocks = ["10.0.0.0/8"]
           }
-
         }
       }
       vmseries_public = {

--- a/examples/isolated_design_autoscale/example.tfvars
+++ b/examples/isolated_design_autoscale/example.tfvars
@@ -107,16 +107,6 @@ vpcs = {
             type        = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
             cidr_blocks = ["10.0.0.0/8"]
           }
-          panorama_mgmt = {
-            description = "Permit Panorama Management"
-            type        = "ingress", from_port = "3978", to_port = "3978", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
-          panorama_log = {
-            description = "Permit Panorama Logging"
-            type        = "ingress", from_port = "28443", to_port = "28443", protocol = "tcp"
-            cidr_blocks = ["10.0.0.0/8"]
-          }
         }
       }
       vmseries_public = {


### PR DESCRIPTION
## Description

PR removes redundant ingress rules in `vmseries_mgmt` security group.

## Motivation and Context

PR resolves #46 .

## How Has This Been Tested?

Code was tested by ChatOps.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
