### PR TITLE
fix: Fix creating routes for sourced subnets

### DIFF
--- a/modules/subnet_set/outputs.tf
+++ b/modules/subnet_set/outputs.tf
@@ -15,7 +15,7 @@ output "route_tables" {
 }
 
 output "unique_route_table_ids" {
-  value = var.create_shared_route_table ? { "shared" = aws_route_table.shared["shared"].id } : { for k, v in aws_route_table.this : k => v.id }
+  value = var.create_shared_route_table ? { "shared" = aws_route_table.shared["shared"].id } : { for k, v in local.route_tables : k => v.id }
 }
 
 output "availability_zones" {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR fixes an `unique_route_table_ids` output in `subnet_set` module, which took the value directly from route table resource block. Meanwhile, the route table can also be sourced using a data source block. Now the output takes value from a local which takes value from a resource block or data source block depending on a create type variable.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Routes for the subnets that were sourced in the code (using data source blocks) were not created in their respective route tables. Basically the `vpc_route` module failed to fetch the Route Table IDs from `subnet_set` module when the subnets were sourced.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested locally from my workstation, with a local copy of the module.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
