### PR TITLE
fix(example/vmseries_standalone): Resolve problem with unstable VM-Series standalone example tests

### DIFF
--- a/examples/vmseries_standalone/main_test.go
+++ b/examples/vmseries_standalone/main_test.go
@@ -24,10 +24,10 @@ func CreateTerraformOptions(t *testing.T, varFiles []string) *terraform.Options 
 		Lock:                 true,
 		Upgrade:              true,
 		SetVarsAfterVarFiles: true,
-		RetryableTerraformErrors: map[string]string{
-			"The specified key does not exist": "Temporary solution for problem with listing tags for S3 (Simple Storage) Object - operation error S3: GetObjectTagging, https response error StatusCode: 404, api error NoSuchKey: The specified key does not exist",
-		},
 	})
+
+	terraformOptions.RetryableTerraformErrors[".*The specified key does not exist.*"] = "Solution for problem with listing tags for S3 (Simple Storage) Object - operation error S3: GetObjectTagging, https response error StatusCode: 404, api error NoSuchKey: The specified key does not exist"
+	terraformOptions.RetryableTerraformErrors[".*couldn't find resource.*"] = "Solution for problem with reading objects from S3 (Simple Storage) Object - reading S3 Object (config/): couldn't find resource"
 
 	return terraformOptions
 }

--- a/examples/vmseries_standalone/main_test.go
+++ b/examples/vmseries_standalone/main_test.go
@@ -26,8 +26,8 @@ func CreateTerraformOptions(t *testing.T, varFiles []string) *terraform.Options 
 		SetVarsAfterVarFiles: true,
 	})
 
-	terraformOptions.RetryableTerraformErrors[".*The specified key does not exist.*"] = "Solution for problem with listing tags for S3 (Simple Storage) Object - operation error S3: GetObjectTagging, https response error StatusCode: 404, api error NoSuchKey: The specified key does not exist"
-	terraformOptions.RetryableTerraformErrors[".*couldn't find resource.*"] = "Solution for problem with reading objects from S3 (Simple Storage) Object - reading S3 Object (config/): couldn't find resource"
+	terraformOptions.RetryableTerraformErrors[".*The specified key does not exist.*"] = "Solution for problem with listing tags for S3 - HTTPS response error 404 returned while getting S3 object tags"
+	terraformOptions.RetryableTerraformErrors[".*couldn't find resource.*"] = "Solution for problem with reading objects from S3 - couldn't find resource while reading S3 object"
 
 	return terraformOptions
 }

--- a/examples/vmseries_standalone/main_test.go
+++ b/examples/vmseries_standalone/main_test.go
@@ -24,6 +24,9 @@ func CreateTerraformOptions(t *testing.T, varFiles []string) *terraform.Options 
 		Lock:                 true,
 		Upgrade:              true,
 		SetVarsAfterVarFiles: true,
+		RetryableTerraformErrors: map[string]string{
+			"The specified key does not exist": "Temporary solution for problem with listing tags for S3 (Simple Storage) Object - operation error S3: GetObjectTagging, https response error StatusCode: 404, api error NoSuchKey: The specified key does not exist",
+		},
 	})
 
 	return terraformOptions


### PR DESCRIPTION
## Description

From time to time VM-Series standalone example tests are failing during release e.g. https://github.com/PaloAltoNetworks/terraform-aws-swfw-modules/actions/runs/10294382059/job/28492474494

In order to solve the problem with S3, additional retry was configured. 

## Motivation and Context

From time to time release workflows fails.

## How Has This Been Tested?

Code was tested via ChatOps.

In execution https://github.com/PaloAltoNetworks/terraform-aws-swfw-modules/actions/runs/10364614423/job/28690221035 there was a problem with S3 objects, but workflow didn't fail - it just retried once again after 5 seconds (by default there are max 3 retries):

```
  TestIdempotence 2024-08-13T06:19:15Z retry.go:144: 'terraform [apply -input=false -auto-approve -var-file example.tfvars -var name_prefix=p69-421c- -var ssh_key_name=test-ssh-key -lock=true]' failed with the error 'error while running command: exit status 1; ╷
  │ Error: reading S3 Object (config/): couldn't find resource
  │ 
  │   with module.bootstrap["vmseries-01"].aws_s3_object.bootstrap_dirs["config/"],
  │   on ../../modules/bootstrap/main.tf line 65, in resource "aws_s3_object" "bootstrap_dirs":
  │   65: resource "aws_s3_object" "bootstrap_dirs" {
  │ 
  ╵' but this error was expected and warrants a retry. Further details: Solution for problem with reading objects from S3 - couldn't find resource while reading S3 object
  TestIdempotence 2024-08-13T06:19:15Z retry.go:103: terraform [apply -input=false -auto-approve -var-file example.tfvars -var name_prefix=p69-421c- -var ssh_key_name=test-ssh-key -lock=true] returned an error: error while running command: exit status 1; ╷
  │ Error: reading S3 Object (config/): couldn't find resource
  │ 
  │   with module.bootstrap["vmseries-01"].aws_s3_object.bootstrap_dirs["config/"],
  │   on ../../modules/bootstrap/main.tf line 65, in resource "aws_s3_object" "bootstrap_dirs":
  │   65: resource "aws_s3_object" "bootstrap_dirs" {
  │ 
  ╵. Sleeping for 5s and will try again.
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
