### PR TITLE
fix(modules/asg): Accept entire SG list for ENI in ASG module

### DIFF
--- a/modules/asg/main.tf
+++ b/modules/asg/main.tf
@@ -68,7 +68,7 @@ resource "aws_launch_template" "this" {
 
   network_interfaces {
     device_index                = 0
-    security_groups             = [local.default_eni_sg_ids[0]]
+    security_groups             = local.default_eni_sg_ids
     subnet_id                   = values(local.default_eni_subnet_names[0])[0]
     associate_public_ip_address = try(local.default_eni_public_ip[0])
   }

--- a/modules/asg/scripts/lambda.py
+++ b/modules/asg/scripts/lambda.py
@@ -158,7 +158,7 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
             for k, v in sett.items():
                 interface[eni] = {} if eni not in interface.keys() else interface[eni]
                 interface[eni]["index"] = int(v) if 'device_index' in k else interface.get(eni).get('index')
-                interface[eni]["sg"] = v[0] if 'security_group_ids' in k else interface.get(eni).get('sg')
+                interface[eni]["sg"] = v if 'security_group_ids' in k else interface.get(eni).get('sg')
                 interface[eni]["c_pub_ip"] = v if 'create_public_ip' in k else interface.get(eni).get('c_pub_ip')
                 interface[eni]["s_dest_ch"] = v if 'source_dest_check' in k else interface.get(eni).get('s_dest_ch')
                 if 'subnet_id' in k:
@@ -180,7 +180,7 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
         return instance_info.get('Placement').get('AvailabilityZone') if 'Placement' in instance_info else None, \
             instance_info.get('SubnetId'), instance_info.get('NetworkInterfaces')
 
-    def create_network_interface(self, instance_id: str, subnet_id: str, sg_id: int) -> str:
+    def create_network_interface(self, instance_id: str, subnet_id: str, sg_id: list) -> str:
         """
         As function name, it creates new ENI, if something wrong it catch error.
 
@@ -196,7 +196,7 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
             tag_specifications = [{'Key': k, 'Value': v} for k, v in tags.items()]
             network_interface = self.ec2_client.create_network_interface(
                 SubnetId=subnet_id,
-                Groups=[sg_id],
+                Groups=sg_id,
                 TagSpecifications=[
                     {
                         'ResourceType': 'network-interface',

--- a/modules/asg/scripts/lambda.py
+++ b/modules/asg/scripts/lambda.py
@@ -180,23 +180,23 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
         return instance_info.get('Placement').get('AvailabilityZone') if 'Placement' in instance_info else None, \
             instance_info.get('SubnetId'), instance_info.get('NetworkInterfaces')
 
-    def create_network_interface(self, instance_id: str, subnet_id: str, sg_id: list) -> str:
+    def create_network_interface(self, instance_id: str, subnet_id: str, sg_ids: list) -> str:
         """
         As function name, it creates new ENI, if something wrong it catch error.
 
         :param instance_id: EC2 Instance id
         :param subnet_id: Subnet id
-        :param sg_id: Security group id
+        :param sg_ids: Security group id
         :return: Network Interface id
         """
 
-        self.logger.debug(f"DEBUG: create_interface: instance_id={instance_id}, subnet_id={subnet_id}, sg_id={sg_id}")
+        self.logger.debug(f"DEBUG: create_interface: instance_id={instance_id}, subnet_id={subnet_id}, sg_ids={sg_ids}")
         try:
             tags = loads(getenv('lambda_config')).get('tags')
             tag_specifications = [{'Key': k, 'Value': v} for k, v in tags.items()]
             network_interface = self.ec2_client.create_network_interface(
                 SubnetId=subnet_id,
-                Groups=sg_id,
+                Groups=sg_ids,
                 TagSpecifications=[
                     {
                         'ResourceType': 'network-interface',

--- a/modules/asg/scripts/lambda.py
+++ b/modules/asg/scripts/lambda.py
@@ -186,7 +186,7 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
 
         :param instance_id: EC2 Instance id
         :param subnet_id: Subnet id
-        :param sg_ids: Security group id
+        :param sg_ids: Security group ids
         :return: Network Interface id
         """
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes a problem with `asg` module that prevented attaching more than one Security Group to the instances ENIs. It took the 1st item from the SG list, both in Terraform code and Lambda code (so for ENI created via launch template and those attached with Lambda). Now it accepts a list in both places.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Module attached only 1st Security Group in the list to the ENIs.
#85 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally by deploying the module in the lab.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
