### PR TITLE
fix: Bump panorama panos version to 10.2.8

### DIFF
--- a/examples/panorama_standalone/example.tfvars
+++ b/examples/panorama_standalone/example.tfvars
@@ -70,7 +70,7 @@ panoramas = {
       }
     }
 
-    panos_version = "10.2.3"
+    panos_version = "10.2.8"
 
     network = {
       vpc              = "management_vpc"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR bumps Panorama PAN-OS version from `10.2.3` to `10.2.8` in `panorama_standalone` example.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

CI failed on panorama example because the AMI for 10.2.3 could not be found.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
