### PR TITLE
fix: Change the way to get default KMS for EBS

### DIFF
--- a/examples/centralized_design/README.md
+++ b/examples/centralized_design/README.md
@@ -102,7 +102,6 @@ To enable access from the session manager, the Internet connection for a public 
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
-| [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/centralized_design/main.tf
+++ b/examples/centralized_design/main.tf
@@ -408,10 +408,6 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
-data "aws_kms_alias" "current_arn" {
-  name = data.aws_ebs_default_kms_key.current.key_arn
-}
-
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -454,7 +450,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_kms_alias.current_arn.target_key_arn
+    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
   }
 
   metadata_options {

--- a/examples/centralized_design_autoscale/README.md
+++ b/examples/centralized_design_autoscale/README.md
@@ -183,7 +183,6 @@ statistic    = "Maximum"
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
-| [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/centralized_design_autoscale/main.tf
+++ b/examples/centralized_design_autoscale/main.tf
@@ -414,10 +414,6 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
-data "aws_kms_alias" "current_arn" {
-  name = data.aws_ebs_default_kms_key.current.key_arn
-}
-
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -460,7 +456,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_kms_alias.current_arn.target_key_arn
+    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
   }
 
   metadata_options {

--- a/examples/cloudngfw_combined_design/README.md
+++ b/examples/cloudngfw_combined_design/README.md
@@ -122,7 +122,6 @@ To enable access from the session manager, the Internet connection for a public 
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
-| [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 
 ### Inputs
 

--- a/examples/cloudngfw_combined_design/main.tf
+++ b/examples/cloudngfw_combined_design/main.tf
@@ -248,10 +248,6 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
-data "aws_kms_alias" "current_arn" {
-  name = data.aws_ebs_default_kms_key.current.key_arn
-}
-
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -294,7 +290,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_kms_alias.current_arn.target_key_arn
+    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
   }
 
   metadata_options {

--- a/examples/cloudngfw_isolated_design/README.md
+++ b/examples/cloudngfw_isolated_design/README.md
@@ -118,7 +118,6 @@ To enable access from the session manager, the Internet connection for a public 
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
-| [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 
 ### Inputs
 

--- a/examples/cloudngfw_isolated_design/main.tf
+++ b/examples/cloudngfw_isolated_design/main.tf
@@ -188,10 +188,6 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
-data "aws_kms_alias" "current_arn" {
-  name = data.aws_ebs_default_kms_key.current.key_arn
-}
-
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -234,7 +230,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_kms_alias.current_arn.target_key_arn
+    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
   }
 
   metadata_options {

--- a/examples/combined_design/README.md
+++ b/examples/combined_design/README.md
@@ -136,7 +136,6 @@ If no errors occurred during deployment, configure the VM-Series machines as exp
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
-| [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/combined_design/main.tf
+++ b/examples/combined_design/main.tf
@@ -369,10 +369,6 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
-data "aws_kms_alias" "current_arn" {
-  name = data.aws_ebs_default_kms_key.current.key_arn
-}
-
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -415,7 +411,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_kms_alias.current_arn.target_key_arn
+    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
   }
 
   metadata_options {

--- a/examples/combined_design_autoscale/README.md
+++ b/examples/combined_design_autoscale/README.md
@@ -255,7 +255,6 @@ To enable access from the session manager, the Internet connection for a public 
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
-| [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/combined_design_autoscale/main.tf
+++ b/examples/combined_design_autoscale/main.tf
@@ -374,10 +374,6 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
-data "aws_kms_alias" "current_arn" {
-  name = data.aws_ebs_default_kms_key.current.key_arn
-}
-
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -420,7 +416,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_kms_alias.current_arn.target_key_arn
+    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
   }
 
   metadata_options {

--- a/examples/isolated_design/README.md
+++ b/examples/isolated_design/README.md
@@ -103,7 +103,6 @@ To enable access from the session manager, the Internet connection for a public 
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
-| [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/isolated_design/main.tf
+++ b/examples/isolated_design/main.tf
@@ -331,10 +331,6 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
-data "aws_kms_alias" "current_arn" {
-  name = data.aws_ebs_default_kms_key.current.key_arn
-}
-
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -377,7 +373,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_kms_alias.current_arn.target_key_arn
+    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
   }
 
   metadata_options {

--- a/examples/isolated_design_autoscale/README.md
+++ b/examples/isolated_design_autoscale/README.md
@@ -210,7 +210,6 @@ statistic    = "Maximum"
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
-| [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/isolated_design_autoscale/main.tf
+++ b/examples/isolated_design_autoscale/main.tf
@@ -333,10 +333,6 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
-data "aws_kms_alias" "current_arn" {
-  name = data.aws_ebs_default_kms_key.current.key_arn
-}
-
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -379,7 +375,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_kms_alias.current_arn.target_key_arn
+    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
   }
 
   metadata_options {


### PR DESCRIPTION
## Description

PR fixes the way to get default KMS for EBS in all examples.

## Motivation and Context

#98 

## How Has This Been Tested?

It was tested locally by executing `terraform plan` . If some of the owner can apply all examples using ChatOps, I would be grateful.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
