### PR TITLE
fix(examples): Default EBS KMS Key ARN retrieval

### DIFF
--- a/examples/centralized_design/README.md
+++ b/examples/centralized_design/README.md
@@ -102,6 +102,7 @@ To enable access from the session manager, the Internet connection for a public 
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/centralized_design/main.tf
+++ b/examples/centralized_design/main.tf
@@ -408,6 +408,10 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
+data "aws_kms_key" "current" {
+  key_id = data.aws_ebs_default_kms_key.current.key_arn
+}
+
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -450,7 +454,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
+    kms_key_id            = data.aws_kms_key.current.arn
   }
 
   metadata_options {

--- a/examples/centralized_design_autoscale/README.md
+++ b/examples/centralized_design_autoscale/README.md
@@ -183,6 +183,7 @@ statistic    = "Maximum"
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/centralized_design_autoscale/main.tf
+++ b/examples/centralized_design_autoscale/main.tf
@@ -414,6 +414,10 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
+data "aws_kms_key" "current" {
+  key_id = data.aws_ebs_default_kms_key.current.key_arn
+}
+
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -456,7 +460,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
+    kms_key_id            = data.aws_kms_key.current.arn
   }
 
   metadata_options {

--- a/examples/cloudngfw_combined_design/README.md
+++ b/examples/cloudngfw_combined_design/README.md
@@ -122,6 +122,7 @@ To enable access from the session manager, the Internet connection for a public 
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 
 ### Inputs
 

--- a/examples/cloudngfw_combined_design/main.tf
+++ b/examples/cloudngfw_combined_design/main.tf
@@ -248,6 +248,10 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
+data "aws_kms_key" "current" {
+  key_id = data.aws_ebs_default_kms_key.current.key_arn
+}
+
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -290,7 +294,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
+    kms_key_id            = data.aws_kms_key.current.arn
   }
 
   metadata_options {

--- a/examples/cloudngfw_isolated_design/README.md
+++ b/examples/cloudngfw_isolated_design/README.md
@@ -118,6 +118,7 @@ To enable access from the session manager, the Internet connection for a public 
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 
 ### Inputs
 

--- a/examples/cloudngfw_isolated_design/main.tf
+++ b/examples/cloudngfw_isolated_design/main.tf
@@ -188,6 +188,10 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
+data "aws_kms_key" "current" {
+  key_id = data.aws_ebs_default_kms_key.current.key_arn
+}
+
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -230,7 +234,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
+    kms_key_id            = data.aws_kms_key.current.arn
   }
 
   metadata_options {

--- a/examples/combined_design/README.md
+++ b/examples/combined_design/README.md
@@ -136,6 +136,7 @@ If no errors occurred during deployment, configure the VM-Series machines as exp
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/combined_design/main.tf
+++ b/examples/combined_design/main.tf
@@ -369,6 +369,10 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
+data "aws_kms_key" "current" {
+  key_id = data.aws_ebs_default_kms_key.current.key_arn
+}
+
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -411,7 +415,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
+    kms_key_id            = data.aws_kms_key.current.arn
   }
 
   metadata_options {

--- a/examples/combined_design_autoscale/README.md
+++ b/examples/combined_design_autoscale/README.md
@@ -255,6 +255,7 @@ To enable access from the session manager, the Internet connection for a public 
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/combined_design_autoscale/main.tf
+++ b/examples/combined_design_autoscale/main.tf
@@ -374,6 +374,10 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
+data "aws_kms_key" "current" {
+  key_id = data.aws_ebs_default_kms_key.current.key_arn
+}
+
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -416,7 +420,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
+    kms_key_id            = data.aws_kms_key.current.arn
   }
 
   metadata_options {

--- a/examples/isolated_design/README.md
+++ b/examples/isolated_design/README.md
@@ -103,6 +103,7 @@ To enable access from the session manager, the Internet connection for a public 
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/isolated_design/main.tf
+++ b/examples/isolated_design/main.tf
@@ -331,6 +331,10 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
+data "aws_kms_key" "current" {
+  key_id = data.aws_ebs_default_kms_key.current.key_arn
+}
+
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -373,7 +377,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
+    kms_key_id            = data.aws_kms_key.current.arn
   }
 
   metadata_options {

--- a/examples/isolated_design_autoscale/README.md
+++ b/examples/isolated_design_autoscale/README.md
@@ -210,6 +210,7 @@ statistic    = "Maximum"
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
 | [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs

--- a/examples/isolated_design_autoscale/main.tf
+++ b/examples/isolated_design_autoscale/main.tf
@@ -333,6 +333,10 @@ data "aws_ami" "this" {
 data "aws_ebs_default_kms_key" "current" {
 }
 
+data "aws_kms_key" "current" {
+  key_id = data.aws_ebs_default_kms_key.current.key_arn
+}
+
 resource "aws_iam_role" "spoke_vm_ec2_iam_role" {
   name               = "${var.name_prefix}spoke_vm"
   assume_role_policy = <<EOF
@@ -375,7 +379,7 @@ resource "aws_instance" "spoke_vms" {
   root_block_device {
     delete_on_termination = true
     encrypted             = true
-    kms_key_id            = data.aws_ebs_default_kms_key.current.key_arn
+    kms_key_id            = data.aws_kms_key.current.arn
   }
 
   metadata_options {

--- a/examples/vmseries_standalone/example_ipv6.tfvars
+++ b/examples/vmseries_standalone/example_ipv6.tfvars
@@ -27,7 +27,7 @@ vpcs = {
             cidr_blocks = ["0.0.0.0/0"]
           }
           all_outbound_ipv6 = {
-            description      = "Permit All traffic outbound"
+            description      = "Permit All traffic outbound IPv6"
             type             = "egress", from_port = "0", to_port = "0", protocol = "-1"
             ipv6_cidr_blocks = ["::/0"]
           }
@@ -37,9 +37,9 @@ vpcs = {
             cidr_blocks = ["1.1.1.1/32"] # TODO: update here (replace 1.1.1.1/32 with your IP range)
           }
           https_ipv6 = {
-            description      = "Permit HTTPS"
+            description      = "Permit HTTPS IPv6"
             type             = "ingress", from_port = "443", to_port = "443", protocol = "tcp"
-            ipv6_cidr_blocks = ["2001:DB8::/32"] # TODO: update here (replace 2001:DB8::1 with your IP range)
+            ipv6_cidr_blocks = ["2001:db8::/32"] # TODO: update here (replace 2001:db8::/32 with your IP range)
           }
           ssh = {
             description = "Permit SSH"
@@ -47,9 +47,9 @@ vpcs = {
             cidr_blocks = ["1.1.1.1/32"] # TODO: update here (replace 1.1.1.1/32 with your IP range)
           }
           ssh_ipv6 = {
-            description      = "Permit SSH"
+            description      = "Permit SSH IPv6"
             type             = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
-            ipv6_cidr_blocks = ["2001:DB8::/32"] # TODO: update here (replace 2001:DB8::1 with your IP range)
+            ipv6_cidr_blocks = ["2001:db8::/32"] # TODO: update here (replace 2001:db8::/32 with your IP range)
           }
         }
       }


### PR DESCRIPTION
## Description
The code changes the way KMS EBS default key is associated with an EC2 instance

## Motivation and Context
aws_ebs_default_kms_key returns the alias, not the ARN, even after the key is created. For the code run idempotency it was required to add aws_kms_key to re-apply code without changes to the infrastructure. 

## How Has This Been Tested?
Applying code in the lab 

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
