### PR TITLE
Update variables.tf

### DIFF
--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -122,9 +122,20 @@ variable "interfaces" {
   ]
   ```
   EOF
-  # For now it's not possible to have a more strict definition of variable type, optional
-  # object attributes are still experimental
-  type = map(any)
+  type = map(object({
+    device_index       = number
+    subnet_id          = string
+    name               = optional(string)
+    description        = optional(string)
+    create_public_ip   = optional(bool, false)
+    eip_allocation_id  = optional(string)
+    private_ips        = optional(list(string))
+    ipv6_address_count = optional(number, null)
+    public_ipv4_pool   = optional(string)
+    source_dest_check  = optional(bool, false)
+    security_group_ids = optional(list(string), null)
+  }))
+}
 }
 
 variable "bootstrap_options" {


### PR DESCRIPTION
Add type definition for interfaces

## Description

Add terraform type definition to interfaces variable

## Motivation and Context

With the current definiton it is not possible to mix different types in the variable, the definition I use is otherwise not possible to use with terraform. 

## How Has This Been Tested?

Code is running in production, as this only changes variable definitions, the functionality of the module itself isn't modified. 

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ X] I have added tests to cover my changes if appropriate. 
- [X ] All new and existing tests passed.
