### PR TITLE
feat(modules/bootstrap): Add source_hash to detect file changes in S3 objects

### DIFF
--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -85,9 +85,10 @@ locals {
 resource "aws_s3_object" "bootstrap_files" {
   for_each = fileset(local.source_root_directory, "**/[^.]*")
 
-  bucket = local.aws_s3_bucket.id
-  key    = each.value
-  source = "${local.source_root_directory}/${each.value}"
+  bucket      = local.aws_s3_bucket.id
+  key         = each.value
+  source      = "${local.source_root_directory}/${each.value}"
+  source_hash = filemd5("${local.source_root_directory}/${each.value}")
 }
 
 data "aws_iam_role" "this" {


### PR DESCRIPTION
source_hash parameter on aws_s3_object to make sure a change of the content will trigger an update

## Description

Updated the bootstrap submodule to make sure any local changes on the bootstrap files will be refltected on the S3 bucket.

## Motivation and Context

Customers usually host their TF code and bootstrap file on a VCS with a pipeline running terraform plan and apply.
Before : if the content of a file like authcode (for VM licenses) is changed, the next terraform apply will not detect the changes and won't upload the new version of file on AWS.

## How Has This Been Tested?

Forked the repo included a new parameter on aws s3 objects :
source_hash  = filemd5("${path.module}/bootstrap_directories/${each.value}")

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
