### PR TITLE
feat(examples): Updated examples to default ebs gp3 volume type

### DIFF
--- a/examples/centralized_design/variables.tf
+++ b/examples/centralized_design/variables.tf
@@ -432,7 +432,7 @@ variable "vmseries" {
 
       panos_version   = "10.2.3"
       ebs_kms_id      = "alias/aws/ebs"
-      ebs_volume_type = "gp2"
+      ebs_volume_type = "gp3"
 
       # Value of `vpc` must match key of objects stored in `vpcs`
       vpc = "security_vpc"
@@ -540,7 +540,7 @@ variable "vmseries" {
     instance_type                          = optional(string, "m5.xlarge")
     ebs_encrypted                          = optional(bool, true)
     ebs_kms_id                             = optional(string, "alias/aws/ebs")
-    ebs_volume_type                        = optional(string, "gp2")
+    ebs_volume_type                        = optional(string, "gp3")
     enable_instance_termination_protection = optional(bool, false)
     enable_monitoring                      = optional(bool, false)
     fw_license_type                        = optional(string, "byol")

--- a/examples/centralized_design_autoscale/variables.tf
+++ b/examples/centralized_design_autoscale/variables.tf
@@ -439,7 +439,7 @@ variable "vmseries_asgs" {
 
       panos_version   = "10.2.3"
       ebs_kms_id      = "alias/aws/ebs"
-      ebs_volume_type = "gp2"
+      ebs_volume_type = "gp3"
 
       vpc               = "security_vpc"
       gwlb              = "security_gwlb"
@@ -569,7 +569,7 @@ variable "vmseries_asgs" {
     instance_type                          = optional(string, "m5.xlarge")
     ebs_encrypted                          = optional(bool, true)
     ebs_kms_id                             = optional(string, "alias/aws/ebs")
-    ebs_volume_type                        = optional(string, "gp2")
+    ebs_volume_type                        = optional(string, "gp3")
     enable_instance_termination_protection = optional(bool, false)
     enable_monitoring                      = optional(bool, false)
     fw_license_type                        = optional(string, "byol")

--- a/examples/combined_design/variables.tf
+++ b/examples/combined_design/variables.tf
@@ -466,7 +466,7 @@ variable "vmseries" {
 
       panos_version   = "10.2.3"
       ebs_kms_id      = "alias/aws/ebs"
-      ebs_volume_type = "gp2"
+      ebs_volume_type = "gp3"
 
       # Value of `vpc` must match key of objects stored in `vpcs`
       vpc = "security_vpc"
@@ -570,7 +570,7 @@ variable "vmseries" {
     panos_version                          = string
     airs_deployment                        = optional(bool, false)
     ebs_kms_id                             = string
-    ebs_volume_type                        = optional(string, "gp2")
+    ebs_volume_type                        = optional(string, "gp3")
     vmseries_ami_id                        = optional(string)
     vmseries_product_code                  = optional(string, "6njl1pau431dv1qxipg63mvah")
     include_deprecated_ami                 = optional(bool, false)

--- a/examples/combined_design_autoscale/variables.tf
+++ b/examples/combined_design_autoscale/variables.tf
@@ -440,7 +440,7 @@ variable "vmseries_asgs" {
 
       panos_version   = "10.2.3"
       ebs_kms_id      = "alias/aws/ebs"
-      ebs_volume_type = "gp2"
+      ebs_volume_type = "gp3"
 
       vpc               = "security_vpc"
       gwlb              = "security_gwlb"
@@ -571,7 +571,7 @@ variable "vmseries_asgs" {
     include_deprecated_ami                 = optional(bool, false)
     instance_type                          = optional(string, "m5.xlarge")
     ebs_encrypted                          = optional(bool, true)
-    ebs_volume_type                        = optional(string, "gp2")
+    ebs_volume_type                        = optional(string, "gp3")
     enable_instance_termination_protection = optional(bool, false)
     enable_monitoring                      = optional(bool, false)
     fw_license_type                        = optional(string, "byol")

--- a/examples/isolated_design/variables.tf
+++ b/examples/isolated_design/variables.tf
@@ -377,7 +377,7 @@ variable "vmseries" {
 
       panos_version   = "10.2.3"
       ebs_kms_id      = "alias/aws/ebs"
-      ebs_volume_type = "gp2"
+      ebs_volume_type = "gp3"
 
       # Value of `vpc` must match key of objects stored in `vpcs`
       vpc = "security_vpc"
@@ -485,7 +485,7 @@ variable "vmseries" {
     instance_type                          = optional(string, "m5.xlarge")
     ebs_encrypted                          = optional(bool, true)
     ebs_kms_id                             = optional(string, "alias/aws/ebs")
-    ebs_volume_type                        = optional(string, "gp2")
+    ebs_volume_type                        = optional(string, "gp3")
     enable_instance_termination_protection = optional(bool, false)
     enable_monitoring                      = optional(bool, false)
     fw_license_type                        = optional(string, "byol")

--- a/examples/isolated_design_autoscale/variables.tf
+++ b/examples/isolated_design_autoscale/variables.tf
@@ -383,7 +383,7 @@ variable "vmseries_asgs" {
 
       panos_version   = "10.2.3"
       ebs_kms_id      = "alias/aws/ebs"
-      ebs_volume_type = "gp2"
+      ebs_volume_type = "gp3"
 
       vpc               = "security_vpc"
       gwlb              = "security_gwlb"
@@ -513,7 +513,7 @@ variable "vmseries_asgs" {
     instance_type                          = optional(string, "m5.xlarge")
     ebs_encrypted                          = optional(bool, true)
     ebs_kms_id                             = optional(string, "alias/aws/ebs")
-    ebs_volume_type                        = optional(string, "gp2")
+    ebs_volume_type                        = optional(string, "gp3")
     enable_instance_termination_protection = optional(bool, false)
     enable_monitoring                      = optional(bool, false)
     fw_license_type                        = optional(string, "byol")

--- a/examples/panorama_standalone/main.tf
+++ b/examples/panorama_standalone/main.tf
@@ -283,6 +283,7 @@ module "panorama" {
   instance_type          = each.value.common.instance_type
   ssh_key_name           = var.ssh_key_name
   ebs_kms_key_alias      = each.value.common.ebs.kms_key_alias
+  ebs_volume_type        = each.value.common.ebs.ebs_volume_type
   subnet_id              = module.subnet_sets["${each.value.common.network.vpc}-${each.value.common.network.subnet_group}"].subnets[each.value.az].id
   vpc_security_group_ids = [module.vpc[each.value.common.network.vpc].security_group_ids[each.value.common.network.security_group]]
   panorama_iam_role      = aws_iam_instance_profile.this[each.key].name

--- a/examples/panorama_standalone/variables.tf
+++ b/examples/panorama_standalone/variables.tf
@@ -230,6 +230,7 @@ variable "panoramas" {
     - `create_public_ip`: true, if public IP address for management should be created
   - `ebs`: EBS settings defined in object with attributes:
     - `volumes`: list of EBS volumes attached to each instance
+    - `ebs_volume_type`: type of EBS volume used
     - `kms_key_alias`: KMS key alias used for encrypting Panorama EBS
   - `iam`: IAM settings in object with attrbiutes:
     - `create_role`: enable creation of IAM role
@@ -275,7 +276,8 @@ variable "panoramas" {
             ebs_encrypted   = true
           }
         ]
-        kms_key_alias = "aws/ebs"
+        kms_key_alias   = "aws/ebs"
+        ebs_volume_type = "gp3"
       }
 
       iam = {
@@ -313,8 +315,9 @@ variable "panoramas" {
         force_detach    = optional(bool, false)
         skip_destroy    = optional(bool, false)
       }))
-      encrypted     = bool
-      kms_key_alias = optional(string, "alias/aws/ebs")
+      encrypted       = bool
+      kms_key_alias   = optional(string, "alias/aws/ebs")
+      ebs_volume_type = optional(string, "gp3")
     })
 
     product_code           = optional(string, "eclz7j04vu9lf8ont8ta3n17o")

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -221,6 +221,7 @@ variable "vmseries" {
   - `bootstrap_options`: VM-Seriess bootstrap options used to connect to Panorama
   - `panos_version`: PAN-OS version used for VM-Series
   - `ebs_kms_id`: alias for AWS KMS used for EBS encryption in VM-Series
+  - `ebs_volume_type`: type of EBS volume used
   - `vpc`: key of VPC
   - `gwlb`: key of GWLB
   - `subinterfaces`: configuration of network subinterfaces used to map with GWLB endpoints
@@ -247,8 +248,9 @@ variable "vmseries" {
         dhcp-accept-server-domain   = "yes"
       }
 
-      panos_version = "10.2.3"        # TODO: update here
-      ebs_kms_id    = "alias/aws/ebs" # TODO: update here
+      panos_version   = "10.2.3"        # TODO: update here
+      ebs_kms_id      = "alias/aws/ebs" # TODO: update here
+      ebs_volume_type = "gp3"           # TODO: update here
 
       # Value of `vpc` must match key of objects stored in `vpcs`
       vpc = "security_vpc"
@@ -356,6 +358,7 @@ variable "vmseries" {
     instance_type                          = optional(string, "m5.xlarge")
     ebs_encrypted                          = optional(bool, true)
     ebs_kms_id                             = optional(string, "alias/aws/ebs")
+    ebs_volume_type                        = optional(string, "gp3")
     enable_instance_termination_protection = optional(bool, false)
     enable_monitoring                      = optional(bool, false)
     fw_license_type                        = optional(string, "byol")

--- a/modules/panorama/variables.tf
+++ b/modules/panorama/variables.tf
@@ -183,6 +183,6 @@ variable "eip_domain" {
 
 variable "ebs_volume_type" {
   description = "Indicates the type of ebs volume for EC2 instance"
-  default     = "gp2"
+  default     = "gp3"
   type        = string
 }

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -210,6 +210,6 @@ variable "eip_domain" {
 
 variable "ebs_volume_type" {
   description = "Indicates the type of ebs volume for EC2 instance"
-  default     = "gp2"
+  default     = "gp3"
   type        = string
 }


### PR DESCRIPTION
## Description

This change updates the examples to use default value of gp3 for ebs volumes

## Motivation and Context

Resolves issues in the scenario of customers being blocked from using gp2 volumes by policy

## How Has This Been Tested?

Tested locally with terraform plan and terraform apply

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
