### PR TITLE
(docs): Correct minimum Terraform version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ This repository has the following directory structure:
   `modules` directory.
 
 ## Compatibility
-
-The compatibility with Terraform is defined individually per each module. In general, expect the earliest compatible
-Terraform version to be 0.13.7 across most of the modules.
+ 
+- The compatibility with Terraform is defined individually per each module. In general, expect the earliest compatible
+- Terraform version to be 0.13.7 across most of the modules.
++ The compatibility with Terraform is defined individually per each module. In general, the earliest compatible
++ Terraform version is `1.5.0` across all modules. The AWS provider requirement is `>= 5.17`.
+ 
+ ## Roadmap
 
 ## Roadmap
 
@@ -54,3 +58,4 @@ and credit will always be given. Please follow our [contributing guide](https://
 
 This repository is maintained by [Palo Alto Networks](https://www.paloaltonetworks.com/).
 If you're looking for commercial support or services, send an email to [address not known yet]. -->
+


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

All modules' versions.tf require `>= 1.5.0, < 2.0.0`, but the README still claimed compatibility down to 0.13.7. Update to match the actual constraint and add the AWS provider floor for completeness.

Cheers,
Michael Mendy