### PR TITLE
feat(modules/vmseries): add `instance_id`, `instance_arn`, `private_ips`, `mgmt_ip outputs`

### DIFF
--- a/modules/vmseries/outputs.tf
+++ b/modules/vmseries/outputs.tf
@@ -1,5 +1,16 @@
 output "instance" {
-  value = aws_instance.this
+  description = "The full `aws_instance` object for the VM-Series instance."
+  value       = aws_instance.this
+}
+
+output "instance_id" {
+  description = "ID of the VM-Series EC2 instance."
+  value       = aws_instance.this.id
+}
+
+output "instance_arn" {
+  description = "ARN of the VM-Series EC2 instance."
+  value       = aws_instance.this.arn
 }
 
 output "interfaces" {
@@ -7,7 +18,21 @@ output "interfaces" {
   value       = aws_network_interface.this
 }
 
+output "private_ips" {
+  description = "Map of primary private IPs, keyed by interface name."
+  value       = { for k, v in aws_network_interface.this : k => v.private_ip }
+}
+
 output "public_ips" {
   description = "Map of public IPs created within the module."
   value       = { for k, v in aws_eip.this : k => v.public_ip }
+}
+
+output "mgmt_ip" {
+  description = "Convenience: public IP of the management interface if one exists, else the private IP. `null` if no interface named `mgmt` was supplied."
+  value = try(
+    aws_eip.this["mgmt"].public_ip,
+    aws_network_interface.this["mgmt"].private_ip,
+    null
+  )
 }


### PR DESCRIPTION
Hey Palo Alto Networks, 

The module currently exposes only the full `aws_instance` and `aws_network_interface` objects plus a `public_ips` map. Consumers commonly need the instance ID, ARN, or per-interface private IPs and have to reach into nested objects `(module.fw.instance.id, module.fw.interfaces["mgmt"].private_ip)`. Promoting these to first-class outputs gives a stable contract that doesn't depend on the underlying resource schema.

Cheers,
Michael Mendy