### PR TITLE
feat(modules/asg): Honor interfaces.public_ipv4_pool in scaling Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ modules/asg/scripts/pan_os_python-1.11.0.dist-info/
 modules/asg/scripts/pan_python-0.17.0.dist-info/
 modules/asg/scripts/panos/
 go.sum
+# Python test artifacts
+.venv*/
+__pycache__/
+.pytest_cache/

--- a/modules/asg/scripts/lambda.py
+++ b/modules/asg/scripts/lambda.py
@@ -160,6 +160,7 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
                 interface[eni]["index"] = int(v) if 'device_index' in k else interface.get(eni).get('index')
                 interface[eni]["sg"] = v if 'security_group_ids' in k else interface.get(eni).get('sg')
                 interface[eni]["c_pub_ip"] = v if 'create_public_ip' in k else interface.get(eni).get('c_pub_ip')
+                interface[eni]["pub_pool"] = v if 'public_ipv4_pool' in k else interface.get(eni).get('pub_pool')
                 interface[eni]["s_dest_ch"] = v if 'source_dest_check' in k else interface.get(eni).get('s_dest_ch')
                 if 'subnet_id' in k:
                     for az, subnet in v.items():
@@ -229,17 +230,24 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
                 self.modify_network_interface(interface_id, attachment_id, interface['s_dest_ch'])
             # If EIP is required for ENI, add public IP
             if interface['c_pub_ip']:
-                self.add_public_ip_to_eni(interface_id)
+                self.add_public_ip_to_eni(interface_id, interface.get('pub_pool'))
 
-    def add_public_ip_to_eni(self, interface_id: str):
+    def add_public_ip_to_eni(self, interface_id: str, public_ipv4_pool: str = None):
         """
         This function is used to create public ip and associate it with provided ENI ID.
 
         :param interface_id: Network Interface id
+        :param public_ipv4_pool: EC2 IPv4 address pool to allocate the address from
         :return: none
         """
-        # Get public IP
-        public_ip_allocation = self.ec2_client.allocate_address(Domain='vpc')
+        # Get public IP - only pass the pool when one is configured, otherwise EC2
+        # rejects the request; omitting it allocates from Amazon's pool
+        allocation_args = {'Domain': 'vpc'}
+        if public_ipv4_pool:
+            allocation_args['PublicIpv4Pool'] = public_ipv4_pool
+            self.logger.info(f"Allocating public ip from pool {public_ipv4_pool} for {interface_id}")
+
+        public_ip_allocation = self.ec2_client.allocate_address(**allocation_args)
         self.logger.info(f"Created public ip {public_ip_allocation['PublicIp']} for {interface_id}")
 
         # Associate public IP with ENI

--- a/modules/asg/tests/README.md
+++ b/modules/asg/tests/README.md
@@ -1,0 +1,20 @@
+# ASG Lambda tests
+
+Unit tests for `../scripts/lambda.py`, the Lambda that handles ASG launch and
+terminate lifecycle actions.
+
+These live outside `../scripts` on purpose: `data.archive_file.this` in `main.tf`
+zips `source_dir = ${path.module}/scripts` wholesale, so anything placed there
+ships inside the deployed Lambda payload.
+
+## Running
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r modules/asg/tests/requirements-dev.txt
+pytest modules/asg/tests/
+```
+
+The Lambda runs on `python3.11`. On Python 3.12 and newer, `pan-os-python==1.11.0`
+imports `distutils`, which was removed from the standard library - install
+`setuptools` in the virtualenv to restore the shim.

--- a/modules/asg/tests/conftest.py
+++ b/modules/asg/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Test configuration for the ASG lifecycle Lambda.
+
+The Lambda source lives in `../scripts` and is packaged by `archive_file`
+(source_dir = ${path.module}/scripts), so tests are kept outside that
+directory to keep them out of the deployed payload.
+
+`lambda.py` cannot be imported by name - `lambda` is a Python keyword - so it is
+loaded from its path and registered under the alias `lambda_function_under_test`.
+"""
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from sys import modules
+
+MODULE_ALIAS = "lambda_function_under_test"
+LAMBDA_SOURCE = Path(__file__).resolve().parent.parent / "scripts" / "lambda.py"
+
+_spec = spec_from_file_location(MODULE_ALIAS, LAMBDA_SOURCE)
+_module = module_from_spec(_spec)
+modules[MODULE_ALIAS] = _module
+_spec.loader.exec_module(_module)

--- a/modules/asg/tests/requirements-dev.txt
+++ b/modules/asg/tests/requirements-dev.txt
@@ -1,0 +1,6 @@
+pytest==9.1.1
+boto3==1.43.69
+# Matches modules/asg/scripts/requirements.txt - lambda.py imports it at module level
+pan-os-python==1.11.0
+# Provides the distutils shim pan-os-python needs on Python 3.12+
+setuptools

--- a/modules/asg/tests/test_lambda.py
+++ b/modules/asg/tests/test_lambda.py
@@ -1,0 +1,150 @@
+"""Behaviour tests for the ASG lifecycle Lambda.
+
+Seams under test:
+  1. `VMSeriesInterfaceScaling.create_interface_settings` - the `interfaces_config`
+     environment variable (as rendered by `jsonencode` in main.tf) is normalised
+     into per-interface settings.
+  2. `VMSeriesInterfaceScaling.add_public_ip_to_eni` - observed through the calls
+     made on the EC2 client.
+  3. `VMSeriesInterfaceScaling.create_and_configure_new_network_interface` - proves
+     settings from seam 1 reach seam 2.
+"""
+from json import dumps
+from logging import getLogger
+
+from pytest import fixture
+
+from lambda_function_under_test import VMSeriesInterfaceScaling
+
+
+class FakeEC2Client:
+    """Stands in for the boto3 EC2 client - the AWS API is a system boundary.
+
+    Records the keyword arguments of every call so tests can assert on the
+    request that would have been sent to EC2.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    def _record(self, operation):
+        def _call(**kwargs):
+            self.calls.append((operation, kwargs))
+            return {
+                'allocate_address': {'AllocationId': 'eipalloc-test', 'PublicIp': '198.51.100.10'},
+                'associate_address': {'AssociationId': 'eipassoc-test'},
+                'create_network_interface': {'NetworkInterface': {'NetworkInterfaceId': 'eni-test'}},
+                'attach_network_interface': {'AttachmentId': 'eni-attach-test'},
+            }.get(operation, {})
+
+        return _call
+
+    def __getattr__(self, operation):
+        return self._record(operation)
+
+    def args_of(self, operation: str) -> dict:
+        """Keyword arguments of the single call made to `operation`."""
+        matching = [kwargs for called, kwargs in self.calls if called == operation]
+        assert len(matching) == 1, f"expected exactly one {operation} call, got {len(matching)}"
+        return matching[0]
+
+
+@fixture
+def interfaces_config(monkeypatch):
+    """Set the `interfaces_config` env var the way main.tf renders it."""
+
+    def _set(interfaces: dict):
+        monkeypatch.setenv("interfaces_config", dumps(interfaces))
+
+    return _set
+
+
+@fixture
+def ec2():
+    return FakeEC2Client()
+
+
+@fixture
+def scaling(ec2, monkeypatch):
+    """A VMSeriesInterfaceScaling wired to a fake EC2 client.
+
+    The constructor both builds boto3 clients and runs the lifecycle action, so
+    the instance is created without it and the boundary client is injected.
+    """
+    monkeypatch.setenv("lambda_config", dumps({"region": "us-east-1", "tags": {"Name": "test"}}))
+    instance = VMSeriesInterfaceScaling.__new__(VMSeriesInterfaceScaling)
+    instance.logger = getLogger("test")
+    instance.ec2_client = ec2
+    return instance
+
+
+def test_interface_settings_carry_the_public_ipv4_pool(interfaces_config):
+    interfaces_config({
+        "untrust": {
+            "device_index": 2,
+            "subnet_id": {"us-east-1a": "subnet-untrust-a"},
+            "create_public_ip": True,
+            "public_ipv4_pool": "ipv4pool-ec2-0123456789abcdef0",
+            "security_group_ids": ["sg-untrust"],
+            "source_dest_check": False,
+        }
+    })
+
+    settings = VMSeriesInterfaceScaling.create_interface_settings("us-east-1a")
+
+    assert settings[0]["pub_pool"] == "ipv4pool-ec2-0123456789abcdef0"
+
+
+def test_eip_is_allocated_from_the_given_public_ipv4_pool(scaling, ec2):
+    scaling.add_public_ip_to_eni("eni-untrust", "ipv4pool-ec2-0123456789abcdef0")
+
+    assert ec2.args_of("allocate_address") == {
+        "Domain": "vpc",
+        "PublicIpv4Pool": "ipv4pool-ec2-0123456789abcdef0",
+    }
+
+
+def test_eip_is_allocated_from_the_amazon_pool_when_none_is_configured(scaling, ec2):
+    scaling.add_public_ip_to_eni("eni-untrust", None)
+
+    assert ec2.args_of("allocate_address") == {"Domain": "vpc"}
+
+
+def test_configured_pool_reaches_eip_allocation_when_an_interface_is_created(
+        scaling, ec2, interfaces_config):
+    """The pool set in Terraform on an interface is the pool the EIP comes from."""
+    interfaces_config({
+        "untrust": {
+            "device_index": 2,
+            "subnet_id": {"us-east-1a": "subnet-untrust-a"},
+            "create_public_ip": True,
+            "public_ipv4_pool": "ipv4pool-ec2-0123456789abcdef0",
+            "security_group_ids": ["sg-untrust"],
+            "source_dest_check": False,
+        }
+    })
+    untrust = VMSeriesInterfaceScaling.create_interface_settings("us-east-1a")[0]
+
+    scaling.create_and_configure_new_network_interface("i-0abc", untrust)
+
+    assert ec2.args_of("allocate_address")["PublicIpv4Pool"] == "ipv4pool-ec2-0123456789abcdef0"
+
+
+def test_unset_pool_falls_back_to_the_amazon_pool_when_an_interface_is_created(
+        scaling, ec2, interfaces_config):
+    """`optional(string)` with no value is rendered as an explicit JSON null."""
+    interfaces_config({
+        "untrust": {
+            "device_index": 2,
+            "subnet_id": {"us-east-1a": "subnet-untrust-a"},
+            "create_public_ip": True,
+            "public_ipv4_pool": None,
+            "security_group_ids": ["sg-untrust"],
+            "source_dest_check": False,
+        }
+    })
+    untrust = VMSeriesInterfaceScaling.create_interface_settings("us-east-1a")[0]
+
+    scaling.create_and_configure_new_network_interface("i-0abc", untrust)
+
+    assert ec2.args_of("allocate_address") == {"Domain": "vpc"}


### PR DESCRIPTION
## Problem

`modules/asg/variables.tf` exposes `public_ipv4_pool` on `var.interfaces` and documents it as *"EC2 IPv4 address pool identifier"*, but the scaling Lambda ignored it.

The value already reaches the Lambda — `main.tf:343` jsonencodes the whole interface object into the `interfaces_config` environment variable:

```hcl
interfaces_config = jsonencode({ for k, v in var.interfaces : k => v if v.device_index != 0 })
```

`lambda.py` simply dropped it. `create_interface_settings` never read the key, and `add_public_ip_to_eni` called `allocate_address(Domain='vpc')` unconditionally. Every EIP attached to an ENI created during a launch lifecycle action came from Amazon's pool, silently ignoring a configured BYOIP pool.

## Change

Three lines of behavior in `modules/asg/scripts/lambda.py`:

- `create_interface_settings` normalizes `public_ipv4_pool` into `pub_pool`
- `create_and_configure_new_network_interface` passes it to `add_public_ip_to_eni`
- `add_public_ip_to_eni(interface_id, public_ipv4_pool=None)` sends `PublicIpv4Pool` to `allocate_address`

`PublicIpv4Pool` is only included when a pool is actually set. `optional(string)` with no value renders as an explicit JSON `null`, and EC2 rejects `PublicIpv4Pool=None`; omitting the parameter preserves the existing Amazon-pool behavior.

**No Terraform changes are required** — the plumbing was already there, and `ec2:AllocateAddress` is already granted in the module's IAM policy.

Release on terminate is unaffected: `clean_eip` uses `release_address(AllocationId=...)`, which is pool-agnostic, so BYOIP addresses return to the correct pool.

## Tests

New `modules/asg/tests/` (pytest, 5 tests). They live outside `scripts/` on purpose — `data.archive_file.this` zips `source_dir = ${path.module}/scripts` wholesale, so tests placed there would ship inside the deployed Lambda payload.

The AWS API is faked at the boto3 client boundary; nothing internal is mocked. `conftest.py` loads `lambda.py` via `importlib` since `lambda` is a reserved word.

| Test | Covers |
|---|---|
| `test_interface_settings_carry_the_public_ipv4_pool` | env JSON → normalized settings |
| `test_eip_is_allocated_from_the_given_public_ipv4_pool` | `allocate_address` receives `PublicIpv4Pool` |
| `test_eip_is_allocated_from_the_amazon_pool_when_none_is_configured` | no pool → `{"Domain": "vpc"}` only |
| `test_configured_pool_reaches_eip_allocation_when_an_interface_is_created` | wiring, config → allocation |
| `test_unset_pool_falls_back_to_the_amazon_pool_when_an_interface_is_created` | Terraform's explicit JSON `null` |

```
$ pytest modules/asg/tests/
5 passed
```

This is the repo's first Python test suite, so `.gitignore` gains `.venv*/`, `__pycache__/` and `.pytest_cache/`.

## Note for reviewers

`modules/vmseries/main.tf:61` uses `lookup(each.value, "public_ipv4_pool", "amazon")` — `"amazon"` is `aws_eip`'s sentinel for the Amazon-provided pool. boto3 has no such sentinel; it expects the parameter to be omitted.

So if someone follows the `vmseries` convention and sets `public_ipv4_pool = "amazon"` on an ASG interface, this change forwards it literally and EC2 will reject the allocation. No in-repo example wires this variable today, so nothing currently hits it. I left it out rather than add untested speculative handling — happy to add a case treating `"amazon"` as "omit" if reviewers would prefer the two modules behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)